### PR TITLE
Fix Swift Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
## Summary
- update swift tools version to 5.10

## Testing
- `swift build` *(fails: type 'Product' has no member 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68487510f2308324a721cd8818cbb7b7